### PR TITLE
Update pear/console_table

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "files": ["rubbish_thor_clone.class.php"]
     },
     "require": {
-        "pear/console_table": "1.2.1",
+        "pear/console_table": "*",
         "mjackson/optionparser": "dev-master"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "34ce6b14054613ac9d3bd8d0b34bd4be",
+    "hash": "40b897a156ce581deb96f90f09afc34f",
     "packages": [
         {
             "name": "mjackson/optionparser",
@@ -31,20 +31,20 @@
         },
         {
             "name": "pear/console_table",
-            "version": "1.2.1",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/RobLoach/Console_Table.git",
-                "reference": "10d89fbbe533351dcfe5dc1e84de25d9a8395950"
+                "url": "https://github.com/pear/Console_Table.git",
+                "reference": "64100b9ee81852f4fa17823e55d0b385a544f976"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/RobLoach/Console_Table/zipball/10d89fbbe533351dcfe5dc1e84de25d9a8395950",
-                "reference": "10d89fbbe533351dcfe5dc1e84de25d9a8395950",
+                "url": "https://api.github.com/repos/pear/Console_Table/zipball/64100b9ee81852f4fa17823e55d0b385a544f976",
+                "reference": "64100b9ee81852f4fa17823e55d0b385a544f976",
                 "shasum": ""
             },
             "require": {
-                "php": ">=4.3.10"
+                "php": ">=5.2.0"
             },
             "suggest": {
                 "pear/Console_Color2": ">=0.1.2"
@@ -82,7 +82,7 @@
             "keywords": [
                 "console"
             ],
-            "time": "2014-10-27 10:04:49"
+            "time": "2016-01-21 16:14:31"
         }
     ],
     "packages-dev": [],
@@ -92,6 +92,7 @@
         "mjackson/optionparser": 20
     },
     "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": [],
     "platform-dev": []
 }


### PR DESCRIPTION
This is to get rid of this warning:

```
Methods with the same name as their class will not be constructors in a future version of PHP; Console_Table has a deprecated constructor
```