### PR TITLE
Validate `help` command argument exists

### DIFF
--- a/rubbish_thor_clone.class.php
+++ b/rubbish_thor_clone.class.php
@@ -70,6 +70,11 @@ abstract class RubbishThorClone {
   }
 
   protected function help($command) {
+    # ensure the command exists
+    if(!isset($this->command_defs[$command])) {
+      $this->die_with_usage_error("cannot provide help for unknown command");
+    }
+
     $help_command = $this->command_defs[$command];
 
     echo basename($this->executable) . " {$this->command} ";


### PR DESCRIPTION
#### Because:

* RubbishThorClone does not currently catch invalid commands passed to
  help.
* It'd be more helpful to check and exit with an informative error
  rather than a list of notices.

#### This change:

* Adds a guard statement to the start of the `help` function to ensure
  the command argument exists and exits with a usage error if not.

Fixes #5